### PR TITLE
feat: Convert categorical features to numeric

### DIFF
--- a/finding_donors.ipynb
+++ b/finding_donors.ipynb
@@ -327,10 +327,10 @@
    "outputs": [],
    "source": [
     "# TODO: One-hot encode the 'features_log_minmax_transform' data using pandas.get_dummies()\n",
-    "features_final = None\n",
+    "features_final = pd.get_dummies(features_log_minmax_transform)\n",
     "\n",
     "# TODO: Encode the 'income_raw' data to numerical values\n",
-    "income = None\n",
+    "income = income_raw.replace(to_replace = ['>50K', '<=50K'], value = [1, 0])\n",
     "\n",
     "# Print the number of features after one-hot encoding\n",
     "encoded = list(features_final.columns)\n",


### PR DESCRIPTION
Preprocess data using one-hot encoding scheme.
Typically, learning algorithms expect input to be numeric, which
requires that non-numeric features (called categorical variables)
be converted.